### PR TITLE
SP-1036: Add gitattributes file and bump version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# These files/directories are not included when making
+# an archive of this repository.
+
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -28,7 +28,7 @@ class Config
     public const BITPAY_PROD_TOKEN_URL = 'https://bitpay.com/tokens';
     public const API_HOST_DEV = 'test.bitpay.com';
     public const API_HOST_PROD = 'bitpay.com';
-    public const EXTENSION_VERSION = 'Bitpay_BPCheckout_Magento2_9.3.0';
+    public const EXTENSION_VERSION = 'Bitpay_BPCheckout_Magento2_10.0.0';
     public const BITPAY_PAYMENT_METHOD_NAME = 'bpcheckout';
     public const BITPAY_PAYMENT_ICON = 'Pay-with-BitPay-CardGroup.svg';
     public const BITPAY_PAYMENT_DIR_IMAGES = 'images';

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "",
     "type": "magento2-module",
     "license": "mit",
-    "version":"9.3.0",
+    "version":"10.0.0",
     "authors": [
         {
             "email": "integrations@bitpay.com",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -6,5 +6,5 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Bitpay_BPCheckout" setup_version="9.3.0"></module>
+    <module name="Bitpay_BPCheckout" setup_version="10.0.0"></module>
 </config>


### PR DESCRIPTION
This merge request adds a gitattributes file so we don't export the .gitignore file. Additionally, it bumps the version to 10.0.0